### PR TITLE
Update for newer versions of puppet

### DIFF
--- a/puppet/puppet-test
+++ b/puppet/puppet-test
@@ -26,7 +26,7 @@ pp_tests() {
   # Test the .pp files for syntax errors
   echo "===> Testing the syntax of puppet manifests"
   for file in `find $PUPPET_DIR -type f -name "*.pp"`; do 
-    puppet --parseonly $file || exit 1;
+    puppet parser validate $file || exit 1;
   done
 }
 


### PR DESCRIPTION
Not sure when the --parseonly flag went away but, I have updated the
script the use the parser subcommand that is available in later versions
of puppet.

Thanks for the script though. Super helpful.
