### PR TITLE
Greatly increase speed using xargs

### DIFF
--- a/puppet/puppet-test
+++ b/puppet/puppet-test
@@ -25,9 +25,15 @@ dependencies() {
 pp_tests() {
   # Test the .pp files for syntax errors
   echo "===> Testing the syntax of puppet manifests"
+  
+  # Build a space separated list of all the puppet manifests
+  puppetFiles=""
   for file in `find $PUPPET_DIR -type f -name "*.pp"`; do 
-    puppet parser validate $file || exit 1;
+    puppetFiles="${puppetFiles}$file "
   done
+
+  # Use xargs to avoid the ruby startup penalty as much as possible
+  echo $puppetFiles | xargs puppet parser validate --color=false || exit $?;
 }
 
 erb_tests() {

--- a/puppet/puppet-test
+++ b/puppet/puppet-test
@@ -33,7 +33,7 @@ pp_tests() {
   done
 
   # Use xargs to avoid the ruby startup penalty as much as possible
-  echo $puppetFiles | xargs puppet parser validate --color=false || exit $?;
+  echo $puppetFiles | xargs puppet parser validate || exit $?;
 }
 
 erb_tests() {


### PR DESCRIPTION
Modified pp_tests() to build a list of puppet files. It then uses that list and xargs to call 'puppet parser validate' as few times as possible, since it will accept many files at a time. In my environment, this results in a 18-24x speedup on large puppet code-bases (depending on the system). 
